### PR TITLE
Add performance benchmark for order operations

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -2,9 +2,9 @@ name: Zig CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -1,0 +1,31 @@
+name: Zig CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Zig
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 0.11.0
+      - name: Run tests
+        run: zig build -Doptimize=ReleaseFast test
+      - name: Run benchmark
+        run: zig build -Doptimize=ReleaseFast benchmark
+      - name: Build binaries
+        run: zig build -Doptimize=ReleaseFast
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-binaries
+          path: zig-out/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,9 @@ celerybeat-schedule
 venv/
 ENV/
 
+# Zig build artifacts
+zig-cache/
+zig-out/
 # Spyder project settings
 .spyderproject
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,4 +21,13 @@ set(SOURCE_FILES
 
 add_executable(HFT_Orderbook ${SOURCE_FILES})
 
+# Benchmark executable for measuring latency and throughput
+add_executable(orderbook_benchmark
+        src/performance.c
+        src/datastructs.c
+        src/limits.c
+        src/orders.c
+        src/bst.c
+        src/utils.c)
+
 set(CMAKE_BUILD_TYPE Debug)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,30 @@ Available at Archive.org's WayBackMachine:
 
 https://goo.gl/KF1SRm
 
+## Performance Benchmark
+
+A simple benchmark is provided to measure mean latency and throughput of basic
+order operations. Build and run it with the Zig toolchain:
+
+```
+zig build
+zig build benchmark        # debug build
+zig build -Doptimize=ReleaseFast benchmark  # optimized benchmark
+```
+
+The `benchmark` step executes the harness with 100000 operations and reports
+the average time per operation in microseconds along with the achieved
+throughput in operations per second. The resulting executables are placed in
+`zig-out/bin/` and can also be run directly, e.g. `zig-out/bin/orderbook_benchmark 100000`.
+
+## Prebuilt binaries
+
+Every push and pull request triggers a GitHub Actions workflow that builds the
+project on Linux, macOS and Windows using Zig 0.11.0. The compiled
+`HFT_Orderbook` and `orderbook_benchmark` executables are published as workflow
+artifacts and can be downloaded from the Actions run page for your platform of
+choice.
+
 
     "There are three main operations that a limit order book (LOB) has to
     implement: add, cancel, and execute.  The goal is to implement these

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const link_math = target.os_tag != .windows;
+
+    const common_sources = &[_][]const u8{
+        "src/datastructs.c",
+        "src/limits.c",
+        "src/orders.c",
+        "src/bst.c",
+        "src/utils.c",
+    };
+
+    const include_paths = &[_][]const u8{"src"};
+
+    const exe = b.addExecutable(.{
+        .name = "HFT_Orderbook",
+        .target = target,
+        .optimize = optimize,
+    });
+    for (include_paths) |p| {
+        exe.addIncludePath(.{ .path = p });
+    }
+    for (common_sources) |src_file| {
+        exe.addCSourceFile(.{ .file = .{ .path = src_file }, .flags = &[_][]const u8{} });
+    }
+    exe.addCSourceFile(.{ .file = .{ .path = "src/main.c" }, .flags = &[_][]const u8{} });
+    exe.addCSourceFile(.{ .file = .{ .path = "src/CuTest.c" }, .flags = &[_][]const u8{} });
+    exe.addCSourceFile(.{ .file = .{ .path = "src/testCases.c" }, .flags = &[_][]const u8{} });
+    exe.linkLibC();
+    if (link_math) exe.linkSystemLibrary("m");
+    b.installArtifact(exe);
+
+    const bench = b.addExecutable(.{
+        .name = "orderbook_benchmark",
+        .target = target,
+        .optimize = optimize,
+    });
+    for (include_paths) |p| {
+        bench.addIncludePath(.{ .path = p });
+    }
+    for (common_sources) |src_file| {
+        bench.addCSourceFile(.{ .file = .{ .path = src_file }, .flags = &[_][]const u8{} });
+    }
+    bench.addCSourceFile(.{ .file = .{ .path = "src/performance.c" }, .flags = &[_][]const u8{} });
+    bench.linkLibC();
+    if (link_math) bench.linkSystemLibrary("m");
+    b.installArtifact(bench);
+
+    const test_step = b.step("test", "Run C unit tests");
+    const run_tests = b.addRunArtifact(exe);
+    run_tests.addArg("--test");
+    test_step.dependOn(&run_tests.step);
+
+    const bench_step = b.step("benchmark", "Run performance benchmark");
+    const run_bench = b.addRunArtifact(bench);
+    run_bench.addArg("100000");
+    bench_step.dependOn(&run_bench.step);
+}

--- a/src/performance.c
+++ b/src/performance.c
@@ -1,0 +1,39 @@
+#include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "hftlob.h"
+
+int main(int argc, char *argv[]){
+    long iterations = 100000;
+    if (argc > 1) {
+        iterations = strtol(argv[1], NULL, 10);
+        if (iterations <= 0) {
+            printf("Invalid iteration count.\n");
+            return 1;
+        }
+    }
+
+    Limit limit;
+    initLimit(&limit);
+    limit.limitPrice = 100.0;
+
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    for (long i = 0; i < iterations; ++i) {
+        Order order;
+        initOrder(&order);
+        order.limit = 100.0;
+        order.shares = 10.0;
+        pushOrder(&limit, &order);
+        removeOrder(&order);
+    }
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    double elapsed = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
+    double latency_us = (elapsed / iterations) * 1e6;
+    double throughput = iterations / elapsed;
+    printf("Performed %ld operations in %f seconds\n", iterations, elapsed);
+    printf("Average latency per operation: %.3f microseconds\n", latency_us);
+    printf("Throughput: %.3f ops/sec\n", throughput);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- conditionally link math library in Zig build for Windows compatibility
- extend CI to build on Linux, macOS, and Windows and publish binaries as artifacts
- document how to download the prebuilt executables from CI

## Testing
- `python -m unittest orderbook_tests.py -v`
- `zig build -Doptimize=ReleaseFast test`
- `zig build -Doptimize=ReleaseFast benchmark`
- `zig build -Doptimize=ReleaseFast`


------
https://chatgpt.com/codex/tasks/task_e_68c1527b9adc8320b38e1aa305b9bdff