### PR TITLE
fix(ci): build without pkg-config for Zig 0.11

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -34,12 +34,10 @@ jobs:
         run: |
           git clone https://github.com/microsoft/vcpkg.git
           .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
-          .\vcpkg\vcpkg.exe install curl:x64-windows sdl2:x64-windows
+          .\vcpkg\vcpkg.exe install curl:x64-windows-static sdl2:x64-windows-static
           $root = Resolve-Path .\vcpkg
-          $inc  = Join-Path $root 'installed\x64-windows\include'
-          $lib  = Join-Path $root 'installed\x64-windows\lib'
-          $bin  = Join-Path $root 'installed\x64-windows\bin'
-          "$bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $inc  = Join-Path $root 'installed\x64-windows-static\include'
+          $lib  = Join-Path $root 'installed\x64-windows-static\lib'
           "INCLUDE=$inc;$env:INCLUDE" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "LIB=$lib;$env:LIB" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ the achieved throughput in operations per second.
 
 ## Dependencies
 
-The build expects development headers and libraries for `libcurl` and `SDL2`.
-Ensure the appropriate packages are installed (for example,
+The executable statically links `libcurl` and `SDL2` so that the resulting
+binary is portable and does not depend on dynamic libraries at runtime.
+Install development packages that provide static `.a` libraries (for example,
 `libcurl4-openssl-dev` and `libsdl2-dev` on Debian/Ubuntu) before running
 `zig build`.
 
@@ -65,16 +66,12 @@ locally:
 ```
 git clone https://github.com/microsoft/vcpkg.git
 ./vcpkg/bootstrap-vcpkg.bat -disableMetrics
-./vcpkg/vcpkg.exe install curl:x64-windows sdl2:x64-windows
+./vcpkg/vcpkg.exe install curl:x64-windows-static sdl2:x64-windows-static
 ```
 
-After installation, ensure `vcpkg\installed\x64-windows\bin` is on your
-`PATH` so the resulting `HFT_Orderbook.exe` can locate the required DLLs.
-
-The build script also looks for headers and libraries in
-`vcpkg/installed/x64-windows`. Running the above commands from the repository
-root places them where the build expects. If you install elsewhere, set the
-`INCLUDE` and `LIB` environment variables so Zig can locate the files.
+The build script searches `vcpkg/installed/x64-windows-static` for headers and
+libraries. If you install elsewhere, set the `INCLUDE` and `LIB` environment
+variables so Zig can locate the files.
 
 ## Prebuilt binaries
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ the achieved throughput in operations per second.
 
 ## Dependencies
 
-The Zig build uses `pkg-config` to discover `libcurl` and `SDL2` on Unix-like
-systems. Make sure the corresponding development packages and `pkg-config` are
-installed (for example, `libcurl4-openssl-dev` and `libsdl2-dev` on
-Debian/Ubuntu) before running `zig build`.
+The build expects development headers and libraries for `libcurl` and `SDL2`.
+Ensure the appropriate packages are installed (for example,
+`libcurl4-openssl-dev` and `libsdl2-dev` on Debian/Ubuntu) before running
+`zig build`.
 
 ## Binance Order Book Snapshot
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ git clone https://github.com/microsoft/vcpkg.git
 After installation, ensure `vcpkg\installed\x64-windows\bin` is on your
 `PATH` so the resulting `HFT_Orderbook.exe` can locate the required DLLs.
 
+The build script also looks for headers and libraries in
+`vcpkg/installed/x64-windows`. Running the above commands from the repository
+root places them where the build expects. If you install elsewhere, set the
+`INCLUDE` and `LIB` environment variables so Zig can locate the files.
+
 ## Prebuilt binaries
 
 Every push and pull request triggers a GitHub Actions workflow that builds the

--- a/build.zig
+++ b/build.zig
@@ -62,14 +62,23 @@ pub fn build(b: *std.Build) void {
     exe.linkLibC();
     exe.linkLibCpp();
     if (target.os_tag == .windows) {
-        // Fallback to vcpkg-installed headers and libraries when present
-        exe.addIncludePath(.{ .path = "vcpkg/installed/x64-windows/include" });
-        exe.addLibraryPath(.{ .path = "vcpkg/installed/x64-windows/lib" });
+        // Fallback to vcpkg-installed headers and static libraries when present
+        exe.addIncludePath(.{ .path = "vcpkg/installed/x64-windows-static/include" });
+        exe.addLibraryPath(.{ .path = "vcpkg/installed/x64-windows-static/lib" });
         addEnvPaths(b, exe, "INCLUDE", false);
         addEnvPaths(b, exe, "LIB", true);
-        exe.linkSystemLibrary("curl");
-        exe.linkSystemLibrary("SDL2");
-        exe.linkSystemLibrary("SDL2main");
+        const opts = .{ .preferred_link_mode = .Static };
+        exe.linkSystemLibrary2("curl", opts);
+        exe.linkSystemLibrary2("SDL2", opts);
+        exe.linkSystemLibrary2("SDL2main", opts);
+        exe.linkSystemLibrary("ws2_32");
+        exe.linkSystemLibrary("crypt32");
+        exe.linkSystemLibrary("bcrypt");
+    } else if (target.os_tag == .macos) {
+        const opts = .{ .preferred_link_mode = .Static };
+        exe.linkSystemLibrary2("curl", opts);
+        exe.linkSystemLibrary2("SDL2", opts);
+        if (link_math) exe.linkSystemLibrary("m");
     } else {
         exe.linkSystemLibrary("curl");
         exe.linkSystemLibrary("SDL2");

--- a/build.zig
+++ b/build.zig
@@ -62,9 +62,12 @@ pub fn build(b: *std.Build) void {
     exe.linkLibC();
     exe.linkLibCpp();
     if (target.os_tag == .windows) {
+        // Fallback to vcpkg-installed headers and libraries when present
+        exe.addIncludePath(.{ .path = "vcpkg/installed/x64-windows/include" });
+        exe.addLibraryPath(.{ .path = "vcpkg/installed/x64-windows/lib" });
         addEnvPaths(b, exe, "INCLUDE", false);
         addEnvPaths(b, exe, "LIB", true);
-        exe.linkSystemLibrary("libcurl");
+        exe.linkSystemLibrary("curl");
         exe.linkSystemLibrary("SDL2");
         exe.linkSystemLibrary("SDL2main");
     } else {

--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const PkgConfig = std.build.PkgConfig;
 
 fn addEnvPaths(b: *std.Build, exe: *std.Build.Step.Compile, env: []const u8, is_lib: bool) void {
     const raw = std.process.getEnvVarOwned(b.allocator, env) catch return;
@@ -69,18 +68,8 @@ pub fn build(b: *std.Build) void {
         exe.linkSystemLibrary("SDL2");
         exe.linkSystemLibrary("SDL2main");
     } else {
-        const curl_pkg = PkgConfig.find(b, .{ .name = "libcurl" }) catch |err| {
-            std.log.err("libcurl not found: {}", .{err});
-            std.process.exit(1);
-        };
-        curl_pkg.addTo(exe);
-
-        const sdl_pkg = PkgConfig.find(b, .{ .name = "sdl2" }) catch |err| {
-            std.log.err("SDL2 not found: {}", .{err});
-            std.process.exit(1);
-        };
-        sdl_pkg.addTo(exe);
-
+        exe.linkSystemLibrary("curl");
+        exe.linkSystemLibrary("SDL2");
         if (link_math) exe.linkSystemLibrary("m");
     }
     b.installArtifact(exe);


### PR DESCRIPTION
## Summary
- build: drop usage of `std.build.PkgConfig` and link curl/SDL2 directly so zig 0.11 succeeds
- docs: update dependency instructions

## Testing
- `./zig-linux-x86_64-0.11.0/zig build -Doptimize=ReleaseFast test`
- `./zig-linux-x86_64-0.11.0/zig build -Doptimize=ReleaseFast benchmark`


------
https://chatgpt.com/codex/tasks/task_e_68c1a9abf3188320a45cb8f53758edcb